### PR TITLE
Update type declarations syntax to Crystal 0.12.x

### DIFF
--- a/src/spec2-mocks.cr
+++ b/src/spec2-mocks.cr
@@ -4,8 +4,9 @@ require "mocks"
 
 module Spec2::Mocks
   class HaveReceived < ::Spec2::Matcher
-    @unwrap :: ::Mocks::HaveReceivedExpectation
+    @unwrap : ::Mocks::HaveReceivedExpectation
     getter unwrap
+    
     def initialize(receive)
       @unwrap = ::Mocks::HaveReceivedExpectation.new(receive)
     end


### PR DESCRIPTION
Since 0.12.x Crystal is supporting only a single : for type declarations

More info:

manastech/crystal@2367653
http://crystal-lang.org/docs/syntax_and_semantics/instance_variables_type_inference.html
