### PR TITLE
Add receive expectation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,23 @@ dependencies:
 require "spec2-mocks"
 ```
 
+This additionally adds `before { Mocks.reset }` to each top-level
+`Spec2.describe`.
+
 ### Using `have_received` matcher
 
 ```crystal
 expect(person).to have_received(say("hello world"))
 ```
+
+### Using `receive` matcher
+
+```crystal
+expect(person).to receive(say("hello world"))
+```
+
+This uses `spec2`'s `delayed { ... }` feature to verify expectations after the
+end of the example.
 
 ## Development
 

--- a/spec/spec2-mocks_spec.cr
+++ b/spec/spec2-mocks_spec.cr
@@ -11,9 +11,6 @@ create_mock Greeting do
 end
 
 Spec2.describe "Spec2::Mocks" do
-  before { Mocks.reset }
-  after { Mocks.reset }
-
   it "works" do
     p = Greeting.new
     p.say("hi John")
@@ -22,5 +19,23 @@ Spec2.describe "Spec2::Mocks" do
     expect {
       expect(p).to have_received(say("hello world"))
     }.to raise_error(Spec2::ExpectationNotMet, "expected: say[\"hello world\"]\n     got: say[\"hi John\"]")
+  end
+
+  it "works with delayed expectation (and_return)" do
+    p = Greeting.new
+    expect(p).to receive(say("hi John")).and_return("hello John")
+    expect(p.say("hi John")).to eq("hello John")
+  end
+
+  it "works with delayed expectation (just receive)" do
+    p = Greeting.new
+    expect(p).to receive(say("hi John"))
+    expect(p.say("hi John")).to eq("hi John")
+  end
+
+  it "works with delayed expectation (not_to)" do
+    p = Greeting.new
+    expect(p).not_to receive(say("hi John"))
+    expect(p.say("hi Bruce")).to eq("hi Bruce")
   end
 end

--- a/spec/spec2-mocks_spec.cr
+++ b/spec/spec2-mocks_spec.cr
@@ -6,7 +6,7 @@ class Greeting
   end
 end
 
-create_mock Greeting do
+Mocks.create_mock Greeting do
   mock say(what)
 end
 

--- a/src/spec2-mocks.cr
+++ b/src/spec2-mocks.cr
@@ -2,13 +2,38 @@ require "./spec2-mocks/*"
 require "spec2"
 require "mocks"
 
-module Spec2::Mocks
+module ::Spec2::Mocks
+  class Expectation(T) < ::Spec2::Expectation(T)
+    def initialize(@actual : T, @delayed)
+    end
+
+    def to(m : ::Mocks::Message)
+      allow(@actual).to m
+      delayed_have_received(to, m)
+    end
+
+    def to(m : ::Mocks::Receive)
+      delayed_have_received(to, m)
+    end
+
+    def not_to(m : ::Mocks::Receive)
+      delayed_have_received(not_to, m)
+    end
+
+    macro delayed_have_received(marker, matcher)
+      @delayed << -> do
+        ::Spec2::Expectation.new(@actual)
+          .{{marker.id}} HaveReceived.new({{matcher}})
+      end
+    end
+  end
+
   class HaveReceived
     include ::Spec2::Matcher
 
     @unwrap : ::Mocks::HaveReceivedExpectation
     getter unwrap
-    
+
     def initialize(receive)
       @unwrap = ::Mocks::HaveReceivedExpectation.new(receive)
     end
@@ -31,8 +56,25 @@ module Spec2::Mocks
   end
 end
 
-module Spec2::Matchers
+module ::Spec2::Matchers
   macro have_received(method)
     ::Spec2::Mocks::HaveReceived.new(receive({{method}}))
+  end
+end
+
+module ::Spec2::DSL
+  macro expect(target)
+    ::Spec2::Mocks::Expectation.new({{target}}, __spec2_delayed)
+  end
+
+  #include ::Mocks::Macro::GlobalDSL
+end
+
+module ::Spec2
+  macro describe(what, file = __FILE__, line = __LINE__, &blk)
+    ::Spec2::DSL.context({{what}}, {{file}}, {{line}}) do
+      before { Mocks.reset }
+      {{blk.body}}
+    end
   end
 end

--- a/src/spec2-mocks.cr
+++ b/src/spec2-mocks.cr
@@ -8,7 +8,7 @@ module ::Spec2::Mocks
     end
 
     def to(m : ::Mocks::Message)
-      allow(@actual).to m
+      ::Mocks::Allow.new(@actual).to m
       delayed_have_received(to, m)
     end
 
@@ -56,18 +56,16 @@ module ::Spec2::Mocks
   end
 end
 
-module ::Spec2::Matchers
-  macro have_received(method)
-    ::Spec2::Mocks::HaveReceived.new(receive({{method}}))
-  end
-end
-
 module ::Spec2::DSL
   macro expect(target)
     ::Spec2::Mocks::Expectation.new({{target}}, __spec2_delayed)
   end
 
-  #include ::Mocks::Macro::GlobalDSL
+  include ::Mocks::Macro::GlobalDSL
+
+  macro have_received(method)
+    ::Spec2::Mocks::HaveReceived.new(receive({{method}}))
+  end
 end
 
 module ::Spec2


### PR DESCRIPTION
Enables usage of the following syntaxes:
- `expect(...).to receive(...)`: verifies `have_received(...)` after the test example body
- `expect(...).to receive(...).and_return(...)`: calls respective `allow(...).to receive(...).and_return(...)` right away and verifies `have_received(...)` after the test example body
- `expect(...).not_to receive(...)`: verifies not `have_received(...)` after the test example body

fixes waterlink/mocks.cr#5
